### PR TITLE
Add support for Azure URLs with container@account format

### DIFF
--- a/io/io.go
+++ b/io/io.go
@@ -263,6 +263,18 @@ func inferFileIOFromSchema(ctx context.Context, path string, props map[string]st
 		if err != nil {
 			return nil, err
 		}
+		
+		// For Azure, determine the correct bucket name to use for path processing
+		// If the URL contains @ symbol, extract just the container name
+		bucketName := parsed.Host
+		if strings.Contains(parsed.Host, "@") {
+			parts := strings.Split(parsed.Host, "@")
+			if len(parts) >= 1 {
+				bucketName = parts[0] // Use just the container name part
+			}
+		}
+		
+		return createBlobFS(ctx, bucket, bucketName), nil
 	default:
 		return nil, fmt.Errorf("IO for file '%s' not implemented", path)
 	}


### PR DESCRIPTION
Support Azure URLs in the format `abfs://container@account.dfs.core.windows.net/path`
commonly used by REST catalogs like Polaris, while maintaining backward compatibility
with existing URL formats.

Changes:
- Add parseAzureURL() function to extract container and account names from URLs
- Update createAzureBucket() to use extracted container name instead of raw host
- Modify inferFileIOFromSchema() to pass correct bucket name to createBlobFS()
- Support automatic account name extraction from URLs when not provided in properties

Supported URL formats:
- abfs://container@account.dfs.core.windows.net/path (NEW)
- abfs://account.dfs.core.windows.net/container/path (existing)
- abfs://container/path (existing)

This enables seamless integration with REST catalogs that provide Azure URLs
with embedded container names, fixing URL parsing issues that previously
resulted in "InvalidResourceName" errors.

Fixes: Azure URL parsing for REST catalog integration