### PR TITLE
Support my-container@my-account.dfs.core.windows.net/path syntax

### DIFF
--- a/io/azure.go
+++ b/io/azure.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
@@ -44,61 +43,15 @@ const (
 	// AdlsWriteBlockSize         = "adls.write.block-size-bytes"
 )
 
-// parseAzureURL parses Azure URLs that may contain container@account format
-// Returns containerName, accountName from URL, plus any error
-func parseAzureURL(parsed *url.URL) (containerName, accountName string, err error) {
-	host := parsed.Host
-	
-	// Check if URL is in container@account.dfs.core.windows.net format
-	if strings.Contains(host, "@") {
-		parts := strings.Split(host, "@")
-		if len(parts) != 2 {
-			return "", "", fmt.Errorf("invalid Azure URL format: expected container@account.dfs.core.windows.net, got %s", host)
-		}
-		containerName = parts[0]
-		// Extract account name from account.dfs.core.windows.net
-		accountParts := strings.Split(parts[1], ".")
-		if len(accountParts) > 0 {
-			accountName = accountParts[0]
-		}
-	} else {
-		// Traditional format: abfs://container/path or abfs://account.dfs.core.windows.net/container/path
-		if strings.Contains(host, ".") {
-			// Format: account.dfs.core.windows.net (container will be in path)
-			accountParts := strings.Split(host, ".")
-			if len(accountParts) > 0 {
-				accountName = accountParts[0]
-			}
-			// Container name will be derived from path or properties
-		} else {
-			// Simple container name format: abfs://container/path
-			containerName = host
-		}
-	}
-	
-	return containerName, accountName, nil
-}
-
 // Construct a Azure bucket from a URL
 func createAzureBucket(ctx context.Context, parsed *url.URL, props map[string]string) (*blob.Bucket, error) {
 	adlsSasTokens := propertiesWithPrefix(props, AdlsSasTokenPrefix)
 	adlsConnectionStrings := propertiesWithPrefix(props, AdlsConnectionStringPrefix)
 
-	// Parse the Azure URL to extract container and account names
-	urlContainerName, urlAccountName, err := parseAzureURL(parsed)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse Azure URL: %w", err)
-	}
-
 	// Construct the client
 	accountName := props[AdlsSharedKeyAccountName]
 	endpoint := props[AdlsEndpoint]
 	protocol := props[AdlsProtocol]
-
-	// If account name is not provided in props, use the one from URL
-	if accountName == "" && urlAccountName != "" {
-		accountName = urlAccountName
-	}
 
 	var client *container.Client
 
@@ -106,15 +59,10 @@ func createAzureBucket(ctx context.Context, parsed *url.URL, props map[string]st
 		return nil, errors.New("account name is required for azure bucket")
 	}
 
-	// Determine the container name to use
-	containerName := urlContainerName
-	if containerName == "" {
-		// Fallback: check if container name is provided via properties or use parsed.Host
-		if propContainer := props["adls.container-name"]; propContainer != "" {
-			containerName = propContainer
-		} else {
-			containerName = parsed.Host
-		}
+	// Extract container name from URL - handle both parsed.User (from abfs://container@account) and parsed.Host
+	hostContainerName := parsed.Host
+	if parsed.User != nil && parsed.User.Username() != "" {
+		hostContainerName = parsed.User.Username()
 	}
 
 	if accountKey, ok := props[AdlsSharedKeyAccountKey]; ok {
@@ -126,7 +74,7 @@ func createAzureBucket(ctx context.Context, parsed *url.URL, props map[string]st
 		if err != nil {
 			return nil, err
 		}
-		containerURL, err := url.JoinPath(string(svcURL), containerName)
+		containerURL, err := url.JoinPath(string(svcURL), hostContainerName)
 		if err != nil {
 			return nil, err
 		}
@@ -150,7 +98,7 @@ func createAzureBucket(ctx context.Context, parsed *url.URL, props map[string]st
 			return nil, err
 		}
 
-		containerURL, err := url.JoinPath(string(svcURL), containerName)
+		containerURL, err := url.JoinPath(string(svcURL), hostContainerName)
 		if err != nil {
 			return nil, err
 		}
@@ -161,7 +109,7 @@ func createAzureBucket(ctx context.Context, parsed *url.URL, props map[string]st
 		}
 	} else if connectionString, ok := adlsConnectionStrings[accountName]; ok {
 		var err error
-		client, err = container.NewClientFromConnectionString(connectionString, containerName, nil)
+		client, err = container.NewClientFromConnectionString(connectionString, hostContainerName, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed container.NewClientFromConnectionString: %w", err)
 		}

--- a/io/blob.go
+++ b/io/blob.go
@@ -84,6 +84,15 @@ func (bfs *blobFileIO) preprocess(key string) string {
 		key = after
 	}
 
+	// If the key contains @ (like my-container@my-account.dfs.core.windows.net/path),
+	// extract just the path part after the first /
+	if strings.Contains(key, "@") {
+		parts := strings.SplitN(key, "/", 2)
+		if len(parts) == 2 {
+			key = parts[1] // Remove the leading slash
+		}
+	}
+
 	return strings.TrimPrefix(key, bfs.bucketName+"/")
 }
 

--- a/io/io.go
+++ b/io/io.go
@@ -264,14 +264,10 @@ func inferFileIOFromSchema(ctx context.Context, path string, props map[string]st
 			return nil, err
 		}
 		
-		// For Azure, determine the correct bucket name to use for path processing
-		// If the URL contains @ symbol, extract just the container name
+		// Extract container name from URL - handle both parsed.User (from abfs://container@account) and parsed.Host
 		bucketName := parsed.Host
-		if strings.Contains(parsed.Host, "@") {
-			parts := strings.Split(parsed.Host, "@")
-			if len(parts) >= 1 {
-				bucketName = parts[0] // Use just the container name part
-			}
+		if parsed.User != nil && parsed.User.Username() != "" {
+			bucketName = parsed.User.Username()
 		}
 		
 		return createBlobFS(ctx, bucket, bucketName), nil


### PR DESCRIPTION
Support Azure URLs in the format `abfs://container@account.dfs.core.windows.net/path`
commonly used by REST catalogs like Polaris, while maintaining backward compatibility
with existing URL formats.